### PR TITLE
Feature: Allow optional custom headers in API requests

### DIFF
--- a/src/api/linkdigApi.ts
+++ b/src/api/linkdigApi.ts
@@ -10,13 +10,23 @@ const PAGE_SIZE = 10;
  * Gets the linkding instance URL and token from the settings.
  * @returns The linkding instance URL and token from the settings.
  */
-const getLinkdingSettings = async (): Promise<{ instanceUrl?: string, token?: string }> => {
-    const { instanceUrl, token } = await getSettings();
+const getLinkdingSettings = async (): Promise<{ instanceUrl?: string, token?: string, customHeaders?: Record<string, string> }> => {
+    const { instanceUrl, token, customHeaders } = await getSettings();
 
     if (instanceUrl === undefined || token === undefined)
         throw new Error('Missing Linkdig settings. Please provide them from the Settings page.');
 
-    return { instanceUrl, token };
+    // Convert custom headers array to a record
+    const headersRecord: Record<string, string> = {};
+    if (customHeaders && customHeaders.length > 0) {
+        customHeaders.forEach(header => {
+            if (header.name && header.value) {
+                headersRecord[header.name] = header.value;
+            }
+        });
+    }
+
+    return { instanceUrl, token, customHeaders: headersRecord };
 };
 
 /**
@@ -26,7 +36,7 @@ const getLinkdingSettings = async (): Promise<{ instanceUrl?: string, token?: st
  * @returns The bookmarks from the linkding instance.
  */
 const getBookmarks = async (query?: string, page: number = 0): Promise<BookmarkResult> => {
-    const { instanceUrl, token } = await getLinkdingSettings();
+    const { instanceUrl, token, customHeaders } = await getLinkdingSettings();
 
     // Add a delay to debug loading states
     // await new Promise<void>(resolve => setTimeout(() => resolve(), 2000));
@@ -44,7 +54,8 @@ const getBookmarks = async (query?: string, page: number = 0): Promise<BookmarkR
         url: url.toString(),
         params: params,
         headers: {
-            'Authorization': `Token ${token}`
+            'Authorization': `Token ${token}`,
+            ...customHeaders
         }
     });
 
@@ -64,14 +75,15 @@ const getBookmarks = async (query?: string, page: number = 0): Promise<BookmarkR
  * @returns The bookmark from the linkding instance.
  */
 const getBookmark = async (id: number): Promise<Bookmark> => {
-    const { instanceUrl, token } = await getLinkdingSettings();
+    const { instanceUrl, token, customHeaders } = await getLinkdingSettings();
 
     const url = new URL(`api/bookmarks/${id}/`, instanceUrl);
 
     const response = await CapacitorHttp.get({
         url: url.toString(),
         headers: {
-            'Authorization': `Token ${token}`
+            'Authorization': `Token ${token}`,
+            ...customHeaders
         }
     });
 
@@ -87,7 +99,7 @@ const getBookmark = async (id: number): Promise<Bookmark> => {
  * @returns Information about a URL (title, description, etc.)
  */
 const checkUrl = async (urlToCheck: string): Promise<BookmarkCheckResult> => {
-    const { instanceUrl, token } = await getLinkdingSettings();
+    const { instanceUrl, token, customHeaders } = await getLinkdingSettings();
 
     const url = new URL(`api/bookmarks/check/`, instanceUrl);
 
@@ -97,7 +109,8 @@ const checkUrl = async (urlToCheck: string): Promise<BookmarkCheckResult> => {
             url: urlToCheck
         },
         headers: {
-            'Authorization': `Token ${token}`
+            'Authorization': `Token ${token}`,
+            ...customHeaders
         }
     });
 
@@ -112,7 +125,7 @@ const checkUrl = async (urlToCheck: string): Promise<BookmarkCheckResult> => {
  * @param bookmark The bookmark to create.
  */
 const createBookmark = async (bookmark: Bookmark): Promise<void> => {
-    const { instanceUrl, token } = await getLinkdingSettings();
+    const { instanceUrl, token, customHeaders } = await getLinkdingSettings();
 
     const url = new URL(`api/bookmarks/`, instanceUrl);
 
@@ -127,7 +140,8 @@ const createBookmark = async (bookmark: Bookmark): Promise<void> => {
         },
         headers: {
             'Authorization': `Token ${token}`,
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            ...customHeaders
         }
     });
 };
@@ -137,7 +151,7 @@ const createBookmark = async (bookmark: Bookmark): Promise<void> => {
  * @param bookmark The bookmark to update.
  */
 const updateBookmark = async (bookmark: Bookmark): Promise<void> => {
-    const { instanceUrl, token } = await getLinkdingSettings();
+    const { instanceUrl, token, customHeaders } = await getLinkdingSettings();
 
     const url = new URL(`api/bookmarks/${bookmark.id}/`, instanceUrl);
 
@@ -151,7 +165,8 @@ const updateBookmark = async (bookmark: Bookmark): Promise<void> => {
         },
         headers: {
             'Authorization': `Token ${token}`,
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            ...customHeaders
         }
     });
 };
@@ -161,7 +176,7 @@ const updateBookmark = async (bookmark: Bookmark): Promise<void> => {
  * @param id The id of the bookmark to update.
  */
 const updateBookmarkRead = async (id: number): Promise<void> => {
-    const { instanceUrl, token } = await getLinkdingSettings();
+    const { instanceUrl, token, customHeaders } = await getLinkdingSettings();
 
     const bookmark = await getBookmark(id);
     const url = new URL(`api/bookmarks/${id}/`, instanceUrl);
@@ -171,7 +186,8 @@ const updateBookmarkRead = async (id: number): Promise<void> => {
         data: { unread: !bookmark.unread },
         headers: {
             'Authorization': `Token ${token}`,
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            ...customHeaders
         }
     });
 };
@@ -181,7 +197,7 @@ const updateBookmarkRead = async (id: number): Promise<void> => {
  * @param id The id of the bookmark to delete.
  */
 const deleteBookmark = async (id: number): Promise<void> => {
-    const { instanceUrl, token } = await getLinkdingSettings();
+    const { instanceUrl, token, customHeaders } = await getLinkdingSettings();
 
     const url = new URL(`api/bookmarks/${id}/`, instanceUrl);
 
@@ -189,7 +205,8 @@ const deleteBookmark = async (id: number): Promise<void> => {
         url: url.toString(),
         headers: {
             'Authorization': `Token ${token}`,
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            ...customHeaders
         }
     });
 };
@@ -199,7 +216,7 @@ const deleteBookmark = async (id: number): Promise<void> => {
  * @returns The tags from the linkding instance.
  */
 const getTags = async (): Promise<string[]> => {
-    const { instanceUrl, token } = await getLinkdingSettings();
+    const { instanceUrl, token, customHeaders } = await getLinkdingSettings();
 
     const url = new URL(`api/tags/`, instanceUrl);
 
@@ -209,7 +226,8 @@ const getTags = async (): Promise<string[]> => {
             limit: '1000'
         },
         headers: {
-            'Authorization': `Token ${token}`
+            'Authorization': `Token ${token}`,
+            ...customHeaders
         }
     });
 

--- a/src/api/settingsApi.ts
+++ b/src/api/settingsApi.ts
@@ -13,6 +13,7 @@ const getSettings = async (): Promise<Settings> => {
     const listItemMode = (await Preferences.get({ key: 'listItemMode' })).value;
     const browserMode = (await Preferences.get({ key: 'browserMode' })).value;
     const showFavicons = (await Preferences.get({ key: 'showFavicons' })).value;
+    const customHeaders = (await Preferences.get({ key: 'customHeaders' })).value;
 
     return {
         instanceUrl,
@@ -21,7 +22,8 @@ const getSettings = async (): Promise<Settings> => {
         initialViewMode: initialViewMode || 'unread',
         listItemMode: listItemMode || 'description',
         browserMode: browserMode || 'in-app',
-        showFavicons: showFavicons === 'true'
+        showFavicons: showFavicons === 'true',
+        customHeaders: customHeaders ? JSON.parse(customHeaders) : []
     } as Settings;
 };
 
@@ -41,6 +43,7 @@ const saveSettings = async (settings?: Settings): Promise<void> => {
     await Preferences.set({ key: 'listItemMode', value: settings.listItemMode?.toString() || '' });
     await Preferences.set({ key: 'browserMode', value: settings.browserMode?.toString() || '' });
     await Preferences.set({ key: 'showFavicons', value: settings.showFavicons ? 'true' : 'false' });
+    await Preferences.set({ key: 'customHeaders', value: JSON.stringify(settings.customHeaders || []) });
 };
 
 export {

--- a/src/api/types/settings.ts
+++ b/src/api/types/settings.ts
@@ -2,6 +2,11 @@ import { BrowserMode } from "types/browserMode";
 import { ItemMode } from "types/itemMode";
 import { ViewMode } from "types/viewMode";
 
+export interface CustomHeader {
+    name: string;
+    value: string;
+}
+
 export interface Settings {
     instanceUrl?: string;
     token?: string;
@@ -10,4 +15,5 @@ export interface Settings {
     listItemMode?: ItemMode;
     browserMode?: BrowserMode;
     showFavicons?: boolean;
+    customHeaders?: CustomHeader[];
 }

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -13,11 +13,11 @@ import {
   IonSelectOption,
   IonToggle
 } from "@ionic/react";
-import { checkmarkOutline, closeOutline, helpCircleOutline } from "ionicons/icons";
+import { addOutline, checkmarkOutline, closeOutline, helpCircleOutline, trashOutline } from "ionicons/icons";
 import StandardPage from "components/StandardPage";
 import { tapMedium } from "utils/haptics";
 import useSettings from "hooks/useSettings";
-import { Settings } from "api/types/settings";
+import { CustomHeader, Settings } from "api/types/settings";
 import Footer from "components/Footer";
 
 interface SettingsPageProps {
@@ -70,6 +70,37 @@ const SettingsPage = ({ dismiss }: SettingsPageProps) => {
     setSettings(prev => ({ ...prev, showFavicons: evt.detail.checked } as Settings));
   };
 
+  const handleAddHeader = () => {
+    const newHeader: CustomHeader = { name: '', value: '' };
+    setSettings(prev => ({ 
+      ...prev, 
+      customHeaders: [...(prev?.customHeaders || []), newHeader] 
+    } as Settings));
+  };
+
+  const handleRemoveHeader = (index: number) => {
+    setSettings(prev => ({ 
+      ...prev, 
+      customHeaders: (prev?.customHeaders || []).filter((_, i) => i !== index) 
+    } as Settings));
+  };
+
+  const handleHeaderNameChange = (index: number, value: string) => {
+    setSettings(prev => {
+      const headers = [...(prev?.customHeaders || [])];
+      headers[index] = { ...headers[index], name: value };
+      return { ...prev, customHeaders: headers } as Settings;
+    });
+  };
+
+  const handleHeaderValueChange = (index: number, value: string) => {
+    setSettings(prev => {
+      const headers = [...(prev?.customHeaders || [])];
+      headers[index] = { ...headers[index], value: value };
+      return { ...prev, customHeaders: headers } as Settings;
+    });
+  };
+
   const closeButton = (
     <IonButton onClick={handleCloseButton} title="Cancel">
       <IonIcon slot="icon-only" icon={closeOutline} />
@@ -119,6 +150,58 @@ const SettingsPage = ({ dismiss }: SettingsPageProps) => {
             onIonInput={handleTokenChange}
             helperText="Your REST API token from Settings > Integrations."
           />
+        </IonItem>
+
+        <IonListHeader className="ion-margin-top ion-padding-top">
+          Custom Request Headers
+        </IonListHeader>
+
+        {(settings?.customHeaders || []).map((header, index) => (
+          <div key={index}>
+            <IonItem lines="none">
+              <IonInput
+                label="Header Name"
+                labelPlacement="stacked"
+                value={header.name}
+                autocapitalize="off"
+                autocorrect="off"
+                autocomplete="off"
+                onIonInput={(e) => handleHeaderNameChange(index, e.detail.value || '')}
+                placeholder="e.g., X-Custom-Header"
+              />
+            </IonItem>
+            <IonItem lines="none" className="ion-margin-bottom">
+              <IonInput
+                label="Header Value"
+                labelPlacement="stacked"
+                value={header.value}
+                autocapitalize="off"
+                autocorrect="off"
+                autocomplete="off"
+                onIonInput={(e) => handleHeaderValueChange(index, e.detail.value || '')}
+                placeholder="e.g., custom-value"
+              />
+              <IonButton 
+                slot="end" 
+                fill="clear" 
+                onClick={() => handleRemoveHeader(index)}
+                title="Remove Header"
+              >
+                <IonIcon icon={trashOutline} />
+              </IonButton>
+            </IonItem>
+          </div>
+        ))}
+
+        <IonItem lines="none" className="ion-margin-bottom">
+          <IonButton 
+            expand="block" 
+            fill="outline" 
+            onClick={handleAddHeader}
+          >
+            <IonIcon slot="start" icon={addOutline} />
+            Add Custom Header
+          </IonButton>
         </IonItem>
 
         <IonListHeader className="ion-margin-top ion-padding-top">

--- a/src/pages/SetupPage.tsx
+++ b/src/pages/SetupPage.tsx
@@ -9,15 +9,16 @@ import {
     IonImg,
     IonInput,
     IonItem,
-    IonList
+    IonList,
+    IonListHeader
 } from "@ionic/react";
 import StandardPage from "components/StandardPage";
 import { tapMedium } from "utils/haptics";
 import useSettings from "hooks/useSettings";
-import { Settings } from "api/types/settings";
+import { CustomHeader, Settings } from "api/types/settings";
 import logoHeader from 'assets/logoHeader.png';
 import StandardColumn from "components/StandardColumn";
-import { checkmark } from "ionicons/icons";
+import { addOutline, checkmark, trashOutline } from "ionicons/icons";
 import Footer from "components/Footer";
 
 const SetupPage = () => {
@@ -41,6 +42,37 @@ const SetupPage = () => {
 
     const handleTokenChange = (evt: CustomEvent<InputChangeEventDetail>) => {
         setSettings(prev => ({ ...prev, token: evt.detail.value || '' } as Settings));
+    };
+
+    const handleAddHeader = () => {
+        const newHeader: CustomHeader = { name: '', value: '' };
+        setSettings(prev => ({ 
+            ...prev, 
+            customHeaders: [...(prev?.customHeaders || []), newHeader] 
+        } as Settings));
+    };
+
+    const handleRemoveHeader = (index: number) => {
+        setSettings(prev => ({ 
+            ...prev, 
+            customHeaders: (prev?.customHeaders || []).filter((_, i) => i !== index) 
+        } as Settings));
+    };
+
+    const handleHeaderNameChange = (index: number, value: string) => {
+        setSettings(prev => {
+            const headers = [...(prev?.customHeaders || [])];
+            headers[index] = { ...headers[index], name: value };
+            return { ...prev, customHeaders: headers } as Settings;
+        });
+    };
+
+    const handleHeaderValueChange = (index: number, value: string) => {
+        setSettings(prev => {
+            const headers = [...(prev?.customHeaders || [])];
+            headers[index] = { ...headers[index], value: value };
+            return { ...prev, customHeaders: headers } as Settings;
+        });
     };
 
     return (
@@ -85,6 +117,58 @@ const SetupPage = () => {
                                 onIonInput={handleTokenChange}
                                 helperText="Your REST API token from Settings > Integrations."
                             />
+                        </IonItem>
+
+                        <IonListHeader className="ion-margin-top">
+                            Custom Request Headers (Optional)
+                        </IonListHeader>
+
+                        {(settings?.customHeaders || []).map((header, index) => (
+                            <div key={index}>
+                                <IonItem lines="none">
+                                    <IonInput
+                                        label="Header Name"
+                                        labelPlacement="stacked"
+                                        value={header.name}
+                                        autocapitalize="off"
+                                        autocorrect="off"
+                                        autocomplete="off"
+                                        onIonInput={(e) => handleHeaderNameChange(index, e.detail.value || '')}
+                                        placeholder="e.g., X-Custom-Header"
+                                    />
+                                </IonItem>
+                                <IonItem lines="none" className="ion-padding-bottom">
+                                    <IonInput
+                                        label="Header Value"
+                                        labelPlacement="stacked"
+                                        value={header.value}
+                                        autocapitalize="off"
+                                        autocorrect="off"
+                                        autocomplete="off"
+                                        onIonInput={(e) => handleHeaderValueChange(index, e.detail.value || '')}
+                                        placeholder="e.g., custom-value"
+                                    />
+                                    <IonButton 
+                                        slot="end" 
+                                        fill="clear" 
+                                        onClick={() => handleRemoveHeader(index)}
+                                        title="Remove Header"
+                                    >
+                                        <IonIcon icon={trashOutline} />
+                                    </IonButton>
+                                </IonItem>
+                            </div>
+                        ))}
+
+                        <IonItem lines="none" className="ion-padding-bottom">
+                            <IonButton 
+                                expand="block" 
+                                fill="outline" 
+                                onClick={handleAddHeader}
+                            >
+                                <IonIcon slot="start" icon={addOutline} />
+                                Add Custom Header
+                            </IonButton>
                         </IonItem>
                     </IonList>
 


### PR DESCRIPTION
This is a useful feature for users who run the linkding instance behind an access control (like cloudflare zero trust) and would like to give mobile devices access to the endpoints using http headers as credentials.

Acceptance criteria:

- [x] User can add undefined number of headers (1-∞)
- [x] Headers are *optional*
- [x] Form fields are displayed on (1) SetupPage and (2) SettingsPage

Full disclosure: I did not have time to work through the repository myself, so I let copilot work for me. I carefully tested and reviewed the changes, and I can say I would've not done a better job myself.